### PR TITLE
105 bug daten der route benchmarking

### DIFF
--- a/src/routes/benchmarking/benchmarking.controller.ts
+++ b/src/routes/benchmarking/benchmarking.controller.ts
@@ -3,10 +3,10 @@ import { Benchmarking } from '../../schemas/benchmarking';
 
 export async function getBenchmarking(req: Request, res: Response) {
   try {
-    if (!req.query.userId) {
-      throw new Error();
+    if (!req.query.userId || !req.query.exercise_name) {
+      throw new Error('not all variables were given');
     }
-    const docs = await Benchmarking.find({ userId: req.query.userId }).sort({
+    const docs = await Benchmarking.find({ userId: req.query.userId, exercise_name: req.query.exercise_name }).sort({
       date: -1,
     });
     res.status(200);

--- a/src/schemas/benchmarking.ts
+++ b/src/schemas/benchmarking.ts
@@ -6,7 +6,7 @@ const BenchmarkingSchema = new Schema({
     date: { type: Number, default: Date.now() },
     exercise_amount: { type: Number, required: true },
     exercise_name: { type: String, required: true },
-    week_counter: { type: Number, required: true }
+    week_counter: { type: Number, required: false }
 });
 
 export const Benchmarking = mongoose.model<BenchmarkingDocument, BenchmarkingModel>('Benchmarking', BenchmarkingSchema, 'benchmarking');

--- a/src/schemas/benchmarking.ts
+++ b/src/schemas/benchmarking.ts
@@ -3,7 +3,7 @@ import { BenchmarkingDocument, BenchmarkingModel } from '../types/db/benchmarkin
 
 const BenchmarkingSchema = new Schema({
     userId: { type: String, required: true },
-    date: { type: Number, default: Date.now },
+    date: { type: Number, default: Date.now() },
     exercise_amount: { type: Number, required: true },
     exercise_name: { type: String, required: true },
     week_counter: { type: Number, required: true }

--- a/src/schemas/benchmarking.ts
+++ b/src/schemas/benchmarking.ts
@@ -4,12 +4,8 @@ import { BenchmarkingDocument, BenchmarkingModel } from '../types/db/benchmarkin
 const BenchmarkingSchema = new Schema({
     userId: { type: String, required: true },
     date: { type: Number, default: Date.now },
-    exercise_one_amount: { type: Number, required: true },
-    exercise_one_name: { type: String, required: true },
-    exercise_two_amount: { type: Number, required: false },
-    exercise_two_name: { type: String, required: false },
-    exercise_three_amount: { type: Number, required: false },
-    exercise_three_name: { type: String, required: false },
+    exercise_amount: { type: Number, required: true },
+    exercise_name: { type: String, required: true },
     week_counter: { type: Number, required: true }
 });
 

--- a/src/types/db/benchmarking.types.ts
+++ b/src/types/db/benchmarking.types.ts
@@ -4,12 +4,8 @@ export type TBenchmarking = {
     _id: ObjectId,
     userId: string,
     date: Date,
-    exercise_one_amount: number,
-    exercise_one_name: string,
-    exercise_two_amount: number,
-    exercise_two_name: string,
-    exercise_three_amount: number,
-    exercise_three_name: string,
+    exercise_amount: number,
+    exercise_name: string,
     week_counter: number
 }
 

--- a/test/benchmarking/benchmarking.test.ts
+++ b/test/benchmarking/benchmarking.test.ts
@@ -23,16 +23,20 @@ describe("Benchmarking Endpoint Tests", ()=>{
         await Benchmarking.create({
             _id: "5099803df3f494add2f9d707",
             userId: "5099803df3f414add2f9dba7",
-            exercise_one_amount: 35,
-            exercise_one_name: "pullups",
-            exercise_two_amount: 35,
-            exercise_two_name: "pushups",
-            exercise_three_amount: 125,
-            exercise_three_name: "weightlifting",
+            exercise_amount: 35,
+            exercise_name: "pullups",
             week_counter: 4
         });
+
+        await Benchmarking.create({
+          _id: "5099803df3f494add2f9d708",
+          userId: "5099803df3f414add2f9dba7",
+          exercise_amount: 105,
+          exercise_name: "weightlifting",
+          week_counter: 4
+      });
     
-        const res = await testserver.get("/benchmarking?userId=5099803df3f414add2f9dba7");
+        const res = await testserver.get("/benchmarking?userId=5099803df3f414add2f9dba7&exercise_name=weightlifting");
         expect(res.status).to.equal(200);
       });
 
@@ -46,19 +50,15 @@ describe("Benchmarking Endpoint Tests", ()=>{
     let testbodyofbenchmarking = {
         _id: '5099803da3f494add2f5d757',
         userId: "5099803df3f494add2f9dba7",
-        exercise_one_amount: 35,
-        exercise_one_name: "pullups",
-        exercise_two_amount: 35,
-        exercise_two_name: "pushups",
-        exercise_three_amount: 125,
-        exercise_three_name: "weightlifting",
+        exercise_amount: 35,
+        exercise_name: "pullups",
         week_counter: 4
       };
   
     const res = await testserver.post("/benchmarking").send(testbodyofbenchmarking).set('Accept', 'application/json');
     expect(res.status).to.equal(201);
 
-    const res2 = await testserver.get("/benchmarking?userId=5099803df3f494add2f9dba7");
+    const res2 = await testserver.get("/benchmarking?userId=5099803df3f494add2f9dba7&exercise_name=pullups");
     expect(res2.status).to.equal(200);
   });
 
@@ -66,15 +66,15 @@ describe("Benchmarking Endpoint Tests", ()=>{
     let testbodyofbenchmarking = {
         _id: '5099803da3f494add2f5d757',
         userId: "5099803df3f494add2f9dba7",
-        exercise_one_amount: 35,
-        exercise_one_name: "pullups",
+        exercise_amount: 35,
+        exercise_name: "pullups",
         week_counter: 4
       };
   
     const res = await testserver.post("/benchmarking").send(testbodyofbenchmarking).set('Accept', 'application/json');
     expect(res.status).to.equal(201);
 
-    const res2 = await testserver.get("/benchmarking?userId=5099803df3f494add2f9dba7");
+    const res2 = await testserver.get("/benchmarking?userId=5099803df3f494add2f9dba7&exercise_name=pullups");
     expect(res2.status).to.equal(200);
   });
 


### PR DESCRIPTION
Es wird ab sofort nur noch eine Übung gleichzeitig gesendet. 
Außerdem ist nun bei einer GET-Anfrage auch der Name der Übung verpflichtend anzugeben. 